### PR TITLE
The data of the scan target file into the memory.

### DIFF
--- a/plugin/src/main/groovy/com/github/konifar/gradle/remover/remover/AbstractRemover.groovy
+++ b/plugin/src/main/groovy/com/github/konifar/gradle/remover/remover/AbstractRemover.groovy
@@ -57,18 +57,20 @@ abstract class AbstractRemover {
                         .findAll { it.name != project.rootProject.name }
                         .collect { "${it.projectDir.path}/src" }
         )
-        scanTargetFileTexts = ""
+
+        StringBuilder stringBuilder = new StringBuilder()
         moduleSrcDirs.
                 collect { new File(it) }.
                 findAll { it.exists() }.
                 each { srcDirFile ->
                     srcDirFile.eachDirRecurse { dir ->
                         dir.eachFileMatch(~/(.*\.xml)|(.*\.kt)|(.*\.java)/) { f ->
-                            scanTargetFileTexts += f.text.replaceAll('\n', '').replaceAll(' ', '')
+                            stringBuilder.append(f.text.replaceAll('\n', '').replaceAll(' ', ''))
                         }
                     }
                 }
-
+        scanTargetFileTexts = stringBuilder.toString()
+        
         ColoredLogger.log "[${fileType}] ======== Start ${fileType} checking ========"
 
         moduleSrcDirs.each {


### PR DESCRIPTION
# Issue 

Memory caching and speed up 🚤 #9

# Overview 

The data of the scan target file into the memory on AbstractRemover.

before/after in my project. 😎 

|before|after|
|:-:|:-:|
|<img width="230" alt="2018-05-09 0 45 02" src="https://user-images.githubusercontent.com/749051/39791419-8e89b772-5376-11e8-91ad-47f24958c344.png">|<img width="222" alt="2018-05-08 22 15 09" src="https://user-images.githubusercontent.com/749051/39791423-9008d592-5376-11e8-86cf-727b15d5a642.png">|

## restriction

The data in memory stored per remover. So, Compared to all scans, detection accuracy of unused files decreases. But it is speed up overwhelmingly.
I think that can acceptable.

Thanks.
