### PR TITLE
Fixed some typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Here is two example.
 ```gradle
 unusedResourcesRemover { 
   extraRemovers = [
-    createXmlValueRemover("font", "string", "string"), // fonts.xml
+    createXmlValueRemover("fonts", "string", "string"), // fonts.xml
     createXmlValueRemover("text_appearance", "style", "style", "style") // text_appearance.xml
   ]
   ...
@@ -110,7 +110,7 @@ unusedResourcesRemover {
 }
 ```
 
-To know more, See [UnusedResourcesRemoverExtension](https://github.com/konifar/gradle-unused-resources-remover-plugin/blob/master/plugin/src/main/groovy/com/github/konifar/gradle/remover/remover/UnusedResourcesRemoverExtension.groovy)
+To know more, See [UnusedResourcesRemoverExtension](https://github.com/konifar/gradle-unused-resources-remover-plugin/blob/master/plugin/src/main/groovy/com/github/konifar/gradle/remover/UnusedResourcesRemoverExtension.groovy)
 
 # Contributing
 This project is under development.


### PR DESCRIPTION
Thank you for the really awesome plugin.
We finally got to remove a lot of legacy trashes.

![screenshot](https://user-images.githubusercontent.com/16621708/40158663-affc7dfc-59e0-11e8-9e06-edb6f8bcc452.png)

However when I was reading README to follow the instruction, I found some typo (or unexpected description) and this PR is to fix those. I hope it will help other newers to clean up their project. 